### PR TITLE
Added Android and iOS steps for additional prereq setup to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ samples, guidance on mobile development, and a full API reference.
 You will need to add your own Google Services files for iOS and Android:
 
 - [Docs: Google Services Setup](https://firebase.google.com/docs/flutter/setup)
+
+For Android, you will need to add `android/key.properties` for signing
+
+- [Flutter: Signing the Android App](https://flutter.dev/docs/deployment/android#signing-the-app)
+
+For iOS, if the first build fails, try `brew upgrade` to ensure required tools are up to date.


### PR DESCRIPTION
Two missing steps I had to complete to get both platforms to build on my machine. These are the only additional steps known to me, but we can add more if we find any that others encounter